### PR TITLE
iracing-telem: fixes #1, unaligned read from memory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,12 +296,12 @@ impl Session {
         let x = self.data.as_ptr().add(var_offset);
         if var.hdr.count == 1 {
             match var.hdr.var_type {
-                VarType::Char => Value::Char(*x),
-                VarType::Bool => Value::Bool(*(x as *const bool)),
-                VarType::Int => Value::Int(*(x as *const i32)),
-                VarType::Bitfield => Value::Bitfield(*(x as *const i32)),
-                VarType::Float => Value::Float(*(x as *const f32)),
-                VarType::Double => Value::Double(*(x as *const f64)),
+                VarType::Char => Value::Char(std::ptr::read_unaligned(x as *const u8)),
+                VarType::Bool => Value::Bool(std::ptr::read_unaligned(x as *const bool)),
+                VarType::Int => Value::Int(std::ptr::read_unaligned(x as *const i32)),
+                VarType::Bitfield => Value::Bitfield(std::ptr::read_unaligned(x as *const i32)),
+                VarType::Float => Value::Float(std::ptr::read_unaligned(x as *const f32)),
+                VarType::Double => Value::Double(std::ptr::read_unaligned(x as *const f64)),
                 _ => todo!(), // ETCount
             }
         } else {


### PR DESCRIPTION
Fix crashing issue[1] in debug builds, details below.

This commit changes how the pointer-reads from memory (in unsafe Rust) are checked and handled. Technically, a "misaligned read" can be UB on certain platforms so the Rust compiler (in debug builds) adds a check for the pointer alignment. On modern CPUs, misaligned loads rarely cause issues (exceptions are e.g. cross-page-boundary loads).

The commit here adds a "std::ptr::read_unaligned()" [2] to indicate to the Rust compiler that we know that these pointers may be misaligned, and to emit load assembly instructions that allow this (e.g. loadu, not load for x86 SIMD code).

Release builds worked fine, as the x86 architecture handles the unaligned-ness without issue, and the Rust compiler didn't add a check at runtime to avoid the performance overhead.

For more detail, see these references:
[1] https://github.com/superfell/iracing-telem/issues/1
[2] https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html